### PR TITLE
Fixed case sensitive dependency

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ paragraph=Library to configure MultiWiFi/Credentials at runtime for AVR Mega, Te
 category=Communication
 url=https://github.com/khoih-prog/WiFiManager_NINA_Lite
 architectures=*
-depends=Functional-VLPP,WiFiNINA_Generic,WiFiWebServer,DoubleResetDetector_Generic,FlashStorage_SAMD,FlashStorage_STM32
+depends=Functional-Vlpp,WiFiNINA_Generic,WiFiWebServer,DoubleResetDetector_Generic,FlashStorage_SAMD,FlashStorage_STM32


### PR DESCRIPTION
The case in the `Functional-VLPP` dependency causes library installs to fail:

```
$ arduino-cli lib install WiFiManager_NINA_Lite
Error resolving dependencies for WiFiManager_NINA_Lite: dependency 'Functional-VLPP' is not available
```